### PR TITLE
Improved the ImportData.php file with better slot import and debugging

### DIFF
--- a/maintenance/ImportData.php
+++ b/maintenance/ImportData.php
@@ -59,21 +59,31 @@ class ImportData extends Maintenance {
 		$context->setUser( $user );
 
 		$import = null; // Declare first for recursion
-		$import = static function ( $namespace, $path ) use ( &$error_messages, $context, $importer, &$import ) {
+		$import = static function ( $namespace, $path, $relPath = '' ) use ( &$error_messages, $context, $importer, &$import ) {
 			$files = scandir( $path );
 			foreach ( $files as $file ) {
-				if ( $file === '.' || $file === '..' ) {
+				if ( $file === '.' || $file === '..' || strpos( $file, '.' ) === 0 ) {
 					continue;
 				}
 				$filePath_ = "$path/$file";
 
 				if ( is_dir( $filePath_ ) ) {
-					$import( $namespace, $filePath_ );
+					// A recurse into subdirectory, append to relPath
+					$import( $namespace, $filePath_, $relPath === '' ? $file : "$relPath/$file" );
 
-				} elseif ( is_file( $filePath_ ) ) {				
-					[ $pagename, $slot, $contentModel ] = explode( '.', $file, 3 );
+				} elseif ( is_file( $filePath_ ) ) {
+					// Split filename into base and slot/model
+					$parts = explode( '.', $file, 3 );
+					$baseName = $parts[0];
+					$slot = $parts[1] ?? '';
+					$contentModel = $parts[2] ?? '';
 
-					// slots degined using $wgWSSlotsDefinedSlots
+					// Let Map content models to MediaWiki content models
+					if ( $contentModel === 'lua' ) {
+						$contentModel = 'Scribunto';
+					}
+
+					//  slots degined using $wgWSSlotsDefinedSlots
 					switch ( $slot ) {
 						case 'slot_main':
 							$slotRole = SlotRecord::MAIN;
@@ -113,18 +123,64 @@ class ImportData extends Maintenance {
 						] );
 					}
 
-					echo "importing $namespace:$pagename". PHP_EOL;
+					// let build full page name with submodule support
+					$pagePath = $relPath === '' ? $baseName : "$relPath/$baseName";
+					// For Module namespace, keep / for sub-modules, otherwise use :
+					if ( $namespace === 'Module' ) {
+						$fullPageName = "$namespace:$pagePath";
+					} else {
+						$pagePath = str_replace( '/', ':', $pagePath );
+						$fullPageName = "$namespace:$pagePath";
+					}
+
+					echo "importing $fullPageName". PHP_EOL;
 					// print_r($contents);
-					
+
 					try {
-						$title_ = TitleClass::newFromText( "$namespace:$pagename" );
+						$title_ = TitleClass::newFromText( $fullPageName );
 						$context->setTitle( $title_ );
-						$importer->doImportSelf( "$namespace:$pagename", $contents );
+						$importer->doImportSelf( $fullPageName, $contents );
+						
+						// Debug: Check slots after import
+						$wikiPage = new WikiPage($title_);
+						$revisionRecord = $wikiPage->getRevisionRecord();
+						$slots = $revisionRecord->getSlots()->getSlots();
+						echo "DEBUG Import - Available slots after import for '$fullPageName': ";
+						var_dump(array_keys($slots));
+
+						// --- SLOT FIX: Ensure latest revision has all non-main slots ---
+						$slotRoles = [ 'jsondata', 'header', 'footer' ];
+						$services = MediaWikiServices::getInstance();
+						$slotRoleRegistry = $services->getSlotRoleRegistry();
+						$revisionStore = $services->getRevisionStore();
+						$latestRev = $revisionRecord;
+						$latestRevId = $latestRev->getId();
+						foreach ( $slotRoles as $roleName ) {
+							if ( !$latestRev->hasSlot( $roleName ) ) {
+								// Walk back to find most recent revision with this slot
+								$prevRev = $revisionStore->getPreviousRevision( $latestRev );
+								while ( $prevRev ) {
+									if ( $prevRev->hasSlot( $roleName ) ) {
+										$content = $prevRev->getContent( $roleName );
+										// Add the slot to the latest revision
+										$user = User::newSystemUser( 'Import Script', [ 'steal' => true ] );
+										$pageUpdater = $wikiPage->newPageUpdater( $user );
+										$pageUpdater->setContent( $roleName, $content );
+										$pageUpdater->saveRevision( CommentStoreComment::newUnsavedComment( 'Restored missing slot' ), EDIT_SUPPRESS_RC );
+										echo "Restored missing slot '$roleName' for $fullPageName\n";
+										break;
+									}
+									$prevRev = $revisionStore->getPreviousRevision( $prevRev );
+								}
+							}
+						}
+						// --- END SLOT FIX ---
+
 						echo ' (success)' . PHP_EOL;
 
 					} catch ( \Exception $e ) {
 						echo '***error ' . $e->getMessage();
-						$error_messages[$pagename] = $e->getMessage();
+						$error_messages[$pagePath] = $e->getMessage();
 					}
 					
 				}
@@ -142,6 +198,9 @@ class ImportData extends Maintenance {
 
 		if ( count( $error_messages ) ) {
 			echo '(OSLRef) ***error importing ' . count( $error_messages ) . ' articles' . PHP_EOL;
+			foreach ( $error_messages as $pagename => $message ) {
+				echo "Failed to import: $pagename - Error: $message" . PHP_EOL;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This pr fixes the issue #3 
### **changes made in the importData.php file here:**
- Improved page name construction with proper handling for Module submodules (/) and other namespaces (:).
- The changes made sure the script checks revision history to restore missing non-main slots from old version to the new one like jsondata, header, and footer
- Automatically mapping .lua files to the Scribunto content model.
- Improved the debugging and error reporting with clear slot verification output after import is done an a structured error messages with file paths


